### PR TITLE
更新2025.01.07

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# 项目的下载数据
+data/

--- a/db_config.toml
+++ b/db_config.toml
@@ -5,6 +5,13 @@ cursorclass = "dict"
     charset = "utf8mb4"
     cursorclass = "dict"
 
+[oauth]
+oauth_data_db = 'baidudb'
+oauth_data_table = 'bd_auth_token'
+oauth_data_flag_column_name = 'appId'
+oauth_data_column_value_uid = '1805969627151371'
+
+
 [raw_data_db]
     db = "raw_data"
     charset = "utf8mb4"

--- a/libs/tool.py
+++ b/libs/tool.py
@@ -1,0 +1,113 @@
+from typing import Mapping,Iterator
+import pandas
+import os,sys
+import tomllib
+
+from libs.oceanengine_sdk.src.oceanengine_sdk_py.oncenengine_sdk_client import OceanengineSdkClient
+from libs.oceanengine_sdk.src.oceanengine_sdk_py.db.db_client import DbClient
+from libs.format_converter import convert_dict_keys
+
+
+
+def find_toml_file(
+        filename: str = 'pyproject.toml',
+        raise_error_if_not_found: bool = False,
+        usecwd: bool = False,
+) -> str:
+    """
+    Search in increasingly higher folders for the given file
+
+    Returns path to the file if found, or an empty string otherwise
+    """
+
+    def _is_interactive():
+        """ Decide whether this is running in a REPL or IPython notebook """
+        main = __import__('__main__', None, None, fromlist=['__file__'])
+        return not hasattr(main, '__file__')
+
+    if usecwd or _is_interactive() or getattr(sys, 'frozen', False):
+        # Should work without __file__, e.g. in REPL or IPython notebook.
+        path = os.getcwd()
+    else:
+        # will work for .py files
+        frame = sys._getframe()
+        current_file = __file__
+
+        while frame.f_code.co_filename == current_file:
+            assert frame.f_back is not None
+            frame = frame.f_back
+        frame_filename = frame.f_code.co_filename
+        path = os.path.dirname(os.path.abspath(frame_filename))
+
+    def _walk_to_root(path: str) -> Iterator[str]:
+        """
+        Yield directories starting from the given directory up to the root
+        """
+        if not os.path.exists(path):
+            raise IOError('Starting path not found')
+
+        if os.path.isfile(path):
+            path = os.path.dirname(path)
+
+        last_dir = None
+        current_dir = os.path.abspath(path)
+        while last_dir != current_dir:
+            yield current_dir
+            parent_dir = os.path.abspath(os.path.join(current_dir, os.path.pardir))
+            last_dir, current_dir = current_dir, parent_dir
+
+    for dirname in _walk_to_root(path):
+        check_path = os.path.join(dirname, filename)
+        if os.path.isfile(check_path):
+            return check_path
+
+    if raise_error_if_not_found:
+        raise IOError('File not found')
+
+    return ''
+
+
+def save_data_to_csv(data:list[Mapping], file_name):
+    """
+    将数据保存为csv文件
+    :param data: 数据
+    :param file_name: 文件名
+    :return:None
+    """
+    df = pandas.DataFrame(data)
+    df.to_csv(file_name, index=False, encoding='utf-8_sig')
+    print(f'数据保存成功，文件名：{file_name}')
+
+def get_oauth_client_and_update_token():
+    """
+    从数据库读入oauth相关参数，初始化OceanengineSdkClient，然后调用oauth_sign()自动获取最新的access_token与refresh_token.
+    并将最新的"accessToken", "refreshToken", "expiresTime", "refreshExpiresTime"更新到oauth数据库中。
+    :return:oauthed_oceanengine_client
+    """
+
+    db_config_toml_path = find_toml_file(filename='db_config.toml')
+    if not db_config_toml_path:
+        raise FileNotFoundError('未找到 db_config.toml 文件')
+    with open(db_config_toml_path, 'rb') as f:
+        all_db_config = tomllib.load(f)
+        oauth_config = all_db_config['oauth']
+
+    db_client = DbClient(oauth_config['oauth_data_db'])
+    oceanengine_param = db_client.select(f'select * from {oauth_config['oauth_data_table']} where {oauth_config['oauth_data_flag_column_name']} = "{oauth_config['oauth_data_column_value_uid']}"')
+    format_oceanengine_param = convert_dict_keys(oceanengine_param[0], 'snake')
+    client = OceanengineSdkClient(format_oceanengine_param)
+    new_oauth_token = client.oauth_sign()
+    print(f'new_oauth_token:{new_oauth_token}')
+    format_oauth_token = convert_dict_keys(new_oauth_token, 'small_camel')
+    print(format_oauth_token)
+    update_sql, update_data = db_client.generate_sql(
+        table_name=oauth_config['oauth_data_table'],
+        operation="update",
+        columns=["accessToken", "refreshToken", "expiresTime", "refreshExpiresTime"],
+        data=format_oauth_token,
+        conditions=f'{oauth_config["oauth_data_flag_column_name"]} = "{oauth_config["oauth_data_column_value_uid"]}"'
+    )
+    print(f'sql:{update_sql},data:{update_data}')
+    update_result = db_client.update(update_sql, update_data)
+    print(f'update_result:{update_result}')
+    return client

--- a/src/get_report_fetcher/get_oceanengine_report.py
+++ b/src/get_report_fetcher/get_oceanengine_report.py
@@ -1,49 +1,39 @@
 # -*- coding: utf-8 -*-
-from libs.oceanengine_sdk.src.oceanengine_sdk_py.oncenengine_sdk_client import OceanengineSdkClient
-from libs.oceanengine_sdk.src.oceanengine_sdk_py.db.db_client import DbClient
-from libs.format_converter import convert_dict_keys
-import datetime
-import pandas as pd
+import os
+from libs.tool import save_data_to_csv
+from libs.tool import get_oauth_client_and_update_token
 
+class ReportFetcher:
+    def __init__(self, advertiser_id, custom_config_path='./data/'):
+        self.advertiser_id = advertiser_id
+        self.custom_config_path = custom_config_path
+        if not os.path.exists(self.custom_config_path):
+            os.mkdir(self.custom_config_path)
+        self.oceanengine_client = get_oauth_client_and_update_token()
 
-def get_customer_config(advertiser_id,data_topics):
-    """
-    获取自定义报表可用指标和维度
-    :return:
-    """
-    db_client = DbClient('baidudb')
-    oceanengine_param = db_client.select('select * from bd_auth_token where userName = "创想策划汇"')
-    format_oceanengine_param = convert_dict_keys(oceanengine_param[0], 'snake')
-    client = OceanengineSdkClient(format_oceanengine_param)
-    new_oauth_token = client.oauth_sign()
-    print(f'new_oauth_token:{new_oauth_token}')
-    new_oauth_token = {'app_id': '1805969627151371', 'secret_key': '0cb84b67505483a617f983e3eaf33434b690baab', 'access_token': '6d697d51304d20b1d12417c1975b0c482763621e', 'refresh_token': 'dad5cf8c101b81fdd851d82fbcc1fab1e4fce632', 'expires_time': datetime.datetime(2025, 1, 7, 23, 45, 52, 719997), 'refresh_expires_time': datetime.datetime(2025, 2, 5, 23, 45, 52, 719997), 'auth_code': 'e15b25e0db733a81c4a6019d561d3c74ed23a5be', 'user_id': '92403628013', 'user_name': '创想策划汇'}
-    format_oauth_token = convert_dict_keys(new_oauth_token, 'small_camel')
-    print(format_oauth_token)
-    update_sql, update_data = db_client.generate_sql(
-        table_name="bd_auth_token",
-        operation="update",
-        columns=["accessToken", "refreshToken", "expiresTime", "refreshExpiresTime"],
-        data=format_oauth_token,
-        conditions="userName = '创想策划汇' and appId=1805969627151371"
-    )
-    print(f'sql:{update_sql},data:{update_data}')
-    update_result = db_client.update(update_sql, update_data)
-    print(f'update_result:{update_result}')
-    query_params = {
-        "advertiser_id": advertiser_id,
-        "data_topics": data_topics
-    }
-    _data = client.v3___0_report_custom_config_get(query_params)
-    dimensions_list = _data['data']['list'][0]['dimensions']
-    metrics_list = _data['data']['list'][0]['metrics']
-    df_dimensions = pd.DataFrame(dimensions_list)
-    df_metrics = pd.DataFrame(metrics_list)
-    df_dimensions.to_csv('dimensions.csv', index=False, encoding='utf-8_sig')
-    df_metrics.to_csv('metrics.csv', index=False, encoding='utf-8_sig')
+    def fetch_and_save_custom_configs(self):
+        data_topics = [
+            'BASIC_DATA', 'QUERY_DATA', 'BIDWORD_DATA', 'MATERIAL_DATA',
+            'PRODUCT_DATA', 'ONE_KEY_BOOST_DATA', 'DMP_DATA', 'VIDEO_DUARATION_DATA'
+        ]
+        for topic in data_topics:
+            data = self.get_customer_config(data_topics=[topic])
+            dimensions_file_name = f'{self.custom_config_path}{topic}_dimensions.csv'
+            metrics_file_name = f'{self.custom_config_path}{topic}_metrics.csv'
+            save_data_to_csv(data['data']['list'][0]['dimensions'], dimensions_file_name)
+            save_data_to_csv(data['data']['list'][0]['metrics'], metrics_file_name)
 
-
+    def get_customer_config(self, data_topics):
+        query_params = {
+            "advertiser_id": self.advertiser_id,
+            "data_topics": data_topics
+        }
+        data = self.oceanengine_client.v3___0_report_custom_config_get(query_params)
+        if data['code'] != 0:
+            raise Exception(f'获取自定义报表可用指标和维度失败,code:{data["code"]},message:{data["message"]},requestId:{data["requestId"]}')
+        return data
 
 
 if __name__ == '__main__':
-    get_customer_config(advertiser_id=1801616765879323,data_topics=['BASIC_DATA'])
+    report_fetcher = ReportFetcher(advertiser_id=1801616765879323)
+    report_fetcher.fetch_and_save_custom_configs()


### PR DESCRIPTION
1.迭代了ReportFetcher的代码结构，让代码可读性更好
2.实现了通过toml配置文件来设置oauth的数据库读取与更新
3.将数据持久化本地的功能抽象成模块，放在tool模块中，与功能解耦
4.将oceanengine的client的初始化，已经更新token，并更新数据库功能抽象成get_oauth_client_and_update_token，放在tool模块中。与业务功能解耦。